### PR TITLE
point trickle-down

### DIFF
--- a/Closure_Project/Parser/OfflineParser.py
+++ b/Closure_Project/Parser/OfflineParser.py
@@ -169,5 +169,5 @@ def load_all_dumped():
 
 
 if __name__ == '__main__':
-    load_all_dumped()
+    parse_dump_load_all()
 

--- a/Closure_Project/Parser/OfflineParser.py
+++ b/Closure_Project/Parser/OfflineParser.py
@@ -169,4 +169,5 @@ def load_all_dumped():
 
 
 if __name__ == '__main__':
-    parse_dump_load_all()
+    load_all_dumped()
+


### PR DESCRIPTION
moving extra points between relevant categories: `from_list -> choice`, `choice -> supplementary`, `corner_stone -> choice` etc
happens when calculating `remaining` points for a student.