### PR TITLE
Hotfix DB import/migrations

### DIFF
--- a/Closure_Project/rest_api/huji_loader.py
+++ b/Closure_Project/rest_api/huji_loader.py
@@ -29,10 +29,6 @@ def import_tracks(folder: str = str(TRACK_DUMP_FOLDER_PATH)) -> None:
     track_file_paths = Path(folder).glob("*.json")
     track_dicts = [load_json(str(path)) for path in track_file_paths]
 
-    existing_track_numbers = [t["track_number"] for t in track_dicts]
-    _, delete_dict = Track.objects.filter(track_number__in=existing_track_numbers).delete()
-    print(f"Deleted and re-created conflicting tracks, the resulting deletion counts: {delete_dict} ")
-
     tracks = [Track(**dic) for dic in track_dicts]
     Track.objects.bulk_create(tracks, batch_size=MAX_BATCH_SIZE)
 
@@ -80,9 +76,6 @@ def import_courses(only_add_new: bool, courses_json_file: str = str(COURSE_DUMP_
         existing_ids = {v[1] for v in Course.objects.values_list()}
         parsed = [p for p in parsed if p and p['course_id'] not in existing_ids]
 
-    existing_course_ids = [c['course_id'] for c in parsed]
-    _ , delete_dict = Course.objects.filter(course_id__in=existing_course_ids).delete()
-    print(f"Deleted and re-created conflicting courses, the resulting deletion counts: {delete_dict} ")
     objects = [Course(**dic) for dic in parsed]
     Course.objects.bulk_create(objects, batch_size=MAX_BATCH_SIZE)
 

--- a/Closure_Project/rest_api/migrations/0002_create_superuser.py
+++ b/Closure_Project/rest_api/migrations/0002_create_superuser.py
@@ -14,7 +14,7 @@ def try_get_password_from_secret_manager() -> Optional[str]:
     try:
         # Get project value for identifying current context
         _, project = google.auth.default()
-    except google.exceptions.DefaultCredentialsError:
+    except google.auth.exceptions.DefaultCredentialsError:
         # We are not in a GCP environment
         return None
 


### PR DESCRIPTION
Fixes #124 

One of the issues was that SQLite below version 3.32 [had low limits for the size of a query](https://www.sqlite.org/limits.html#max_variable_number), which caused bulk deletion/insertion queries to fail

The insertion(`bulk_create`) was fixed by by defining a lower batch size via the `batch_size` parameter

Unfortunately, for deletion(`delete`) I couldn't not find the ability to set such parameter. I realized that the need to delete stuff during import is unnecessary as we import during DB migrations, when the DB is clean anyway, so I removed the deletions from the import module.